### PR TITLE
Update to display a per-capita heat map

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ function titleCase(str) {
 
 //ncov map
 function style(feature) {
-    var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100_000;
+    var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100000;
     return {
         fillColor: getColor(per_capita),
         weight: 2,
@@ -186,7 +186,7 @@ function onEachFeature(feature, layer) {
         mouseout: resetHighlight,
         click: zoomToFeature
     });
-        var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100_000;
+        var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100000;
 	var content='<b>' + feature.properties.LOCATION + '<br/>Confirmed: ' + feature.properties.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + feature.properties.ADDED
 			+ '<br/>Cases per capita (100k): ' + per_capita.toFixed(2) + '<br/>'
                         + '</b><br/><font color="#555">Population: ' + numberWithCommas(feature.properties.Pop)
@@ -215,8 +215,8 @@ info.onAdd = function (map) {
 		var content = '<h4>US COVID-19 BY COUNTY<br/>43,945 confirmed, 8,727 added<br/>Dots as Hospitals</h4>'+ 	'<footer><p>Source:<a href="https://coronavirus.1point3acres.com/">coronavirus.1point3acres.com</a> <br/>Update: March 23 2020, 10 pm EST</p></footer>' +  (props ?
 				'<b>' + props.LOCATION + '<br/>Cases per capita (100k): ' +
                                 '(' + ((props.COMFIRMED_COMFIRMED / props.Pop) * 100000).toFixed(4)  + ')<br/>Confirmed: ' + props.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + props.ADDED
-				+ '</b><footer><br/>Puppy Population: ' + numberWithCommas(props.Pop)
-				+ '<br/>Wat Hospital beds: '+ numberWithCommas(props.HospitalBeds)+'<br/>('+ numberWithCommas(Math.round(props.HospitalBeds/props.COMFIRMED_COMFIRMED)) +' beds per confirmed,'
+				+ '</b><footer><br/>Population: ' + numberWithCommas(props.Pop)
+				+ '<br/>Hospital beds: '+ numberWithCommas(props.HospitalBeds)+'<br/>('+ numberWithCommas(Math.round(props.HospitalBeds/props.COMFIRMED_COMFIRMED)) +' beds per confirmed,'
 				+'<br/>assuming all beds for COVID-19)</footer>'
 				: 'Hover over a county');
 

--- a/index.html
+++ b/index.html
@@ -144,8 +144,9 @@ function titleCase(str) {
 
 //ncov map
 function style(feature) {
+    var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100_000;
     return {
-        fillColor: getColor(feature.properties.COMFIRMED_COMFIRMED),
+        fillColor: getColor(per_capita),
         weight: 2,
         opacity: 1,
         color: 'white',
@@ -185,8 +186,10 @@ function onEachFeature(feature, layer) {
         mouseout: resetHighlight,
         click: zoomToFeature
     });
-	content='<b>' + feature.properties.LOCATION + '<br/>Confirmed: ' + feature.properties.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + feature.properties.ADDED
-			+ '</b><br/><font color="#555">Population: ' + numberWithCommas(feature.properties.Pop)
+        var per_capita = (feature.properties.COMFIRMED_COMFIRMED / feature.properties.Pop) * 100_000;
+	var content='<b>' + feature.properties.LOCATION + '<br/>Confirmed: ' + feature.properties.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + feature.properties.ADDED
+			+ '<br/>Cases per capita (100k): ' + per_capita.toFixed(2) + '<br/>'
+                        + '</b><br/><font color="#555">Population: ' + numberWithCommas(feature.properties.Pop)
 			+ '<br/>Hospital beds: '+ numberWithCommas(feature.properties.HospitalBeds)+'<br/>('+ numberWithCommas(Math.round(feature.properties.HospitalBeds/feature.properties.COMFIRMED_COMFIRMED)) +' beds per confirmed)'+'</font>'
 			;
 	layer.bindPopup(content);
@@ -209,12 +212,14 @@ info.onAdd = function (map) {
 
 // add information section
 	info.update = function (props) {
-		content='<h4>US COVID-19 BY COUNTY<br/>43,945 confirmed, 8,727 added<br/>Dots as Hospitals</h4>'+ 	'<footer><p>Source:<a href="https://coronavirus.1point3acres.com/">coronavirus.1point3acres.com</a> <br/>Update: March 23 2020, 10 pm EST</p></footer>' +  (props ?
-				'<b>' + props.LOCATION + '<br/>Confirmed: ' + props.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + props.ADDED
-				+ '</b><footer><br/>Population: ' + numberWithCommas(props.Pop)
-				+ '<br/>Hospital beds: '+ numberWithCommas(props.HospitalBeds)+'<br/>('+ numberWithCommas(Math.round(props.HospitalBeds/props.COMFIRMED_COMFIRMED)) +' beds per confirmed,'
+		var content = '<h4>US COVID-19 BY COUNTY<br/>43,945 confirmed, 8,727 added<br/>Dots as Hospitals</h4>'+ 	'<footer><p>Source:<a href="https://coronavirus.1point3acres.com/">coronavirus.1point3acres.com</a> <br/>Update: March 23 2020, 10 pm EST</p></footer>' +  (props ?
+				'<b>' + props.LOCATION + '<br/>Cases per capita (100k): ' +
+                                '(' + ((props.COMFIRMED_COMFIRMED / props.Pop) * 100000).toFixed(4)  + ')<br/>Confirmed: ' + props.COMFIRMED_COMFIRMED + '<br/>Newly added: ' + props.ADDED
+				+ '</b><footer><br/>Puppy Population: ' + numberWithCommas(props.Pop)
+				+ '<br/>Wat Hospital beds: '+ numberWithCommas(props.HospitalBeds)+'<br/>('+ numberWithCommas(Math.round(props.HospitalBeds/props.COMFIRMED_COMFIRMED)) +' beds per confirmed,'
 				+'<br/>assuming all beds for COVID-19)</footer>'
 				: 'Hover over a county');
+
 	    this._div.innerHTML = content;
 	};
 


### PR DESCRIPTION
Showing raw infection numbers without accounting for the population of a particular county [gives some misleading results](https://xkcd.com/1138/).

Showing number of cases per-capita (e.g. per 100 000 people) is a much more useful metric. 